### PR TITLE
Add rate limiting and NIP-11 relay information

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "ws_server.c" "router.c" "handlers_stub.c" "validator.c" "sub_manager.c" "storage_engine.c" "broadcaster.c" "flash_monitor.c"
+    SRCS "main.c" "ws_server.c" "router.c" "handlers_stub.c" "validator.c" "sub_manager.c" "storage_engine.c" "broadcaster.c" "flash_monitor.c" "rate_limiter.c" "nip11.c"
     INCLUDE_DIRS "."
     REQUIRES esp_http_server esp_wifi nvs_flash esp_timer littlefs
     PRIV_REQUIRES libnostr-c noscrypt

--- a/main/nip11.c
+++ b/main/nip11.c
@@ -1,0 +1,53 @@
+#include "nip11.h"
+#include <string.h>
+
+static const char *NIP11_JSON =
+"{"
+  "\"name\":\"ESP32 Ephemeral Relay\","
+  "\"description\":\"Minimal Nostr relay with 21-day TTL\","
+  "\"pubkey\":\"\","
+  "\"contact\":\"\","
+  "\"supported_nips\":[1,9,11,20,40],"
+  "\"software\":\"https://github.com/privkeyio/wisp-esp32\","
+  "\"version\":\"0.1.0\","
+  "\"limitation\":{"
+    "\"max_message_length\":65536,"
+    "\"max_subscriptions\":8,"
+    "\"max_filters\":4,"
+    "\"max_limit\":500,"
+    "\"max_subid_length\":64,"
+    "\"max_event_tags\":100,"
+    "\"max_content_length\":32768,"
+    "\"min_pow_difficulty\":0,"
+    "\"auth_required\":false,"
+    "\"payment_required\":false"
+  "},"
+  "\"retention\":[{\"kinds\":[0,1,2,3,4,5,6,7],\"time\":1814400}],"
+  "\"relay_countries\":[]"
+"}";
+
+esp_err_t nip11_handler(httpd_req_t *req)
+{
+    char accept[64] = "";
+    httpd_req_get_hdr_value_str(req, "Accept", accept, sizeof(accept));
+
+    if (strstr(accept, "application/nostr+json")) {
+        httpd_resp_set_type(req, "application/nostr+json");
+    } else {
+        httpd_resp_set_type(req, "application/json");
+    }
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Accept");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, OPTIONS");
+    return httpd_resp_send(req, NIP11_JSON, strlen(NIP11_JSON));
+}
+
+esp_err_t nip11_options_handler(httpd_req_t *req)
+{
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Accept");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, OPTIONS");
+    httpd_resp_set_status(req, "204 No Content");
+    return httpd_resp_send(req, NULL, 0);
+}

--- a/main/nip11.h
+++ b/main/nip11.h
@@ -1,0 +1,9 @@
+#ifndef NIP11_H
+#define NIP11_H
+
+#include "esp_http_server.h"
+
+esp_err_t nip11_handler(httpd_req_t *req);
+esp_err_t nip11_options_handler(httpd_req_t *req);
+
+#endif

--- a/main/rate_limiter.c
+++ b/main/rate_limiter.c
@@ -1,0 +1,89 @@
+#include "rate_limiter.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include <string.h>
+
+static const char *TAG = "rate_limiter";
+
+void rate_limiter_init(rate_limiter_t *rl, const rate_config_t *config)
+{
+    memset(rl, 0, sizeof(rate_limiter_t));
+    rl->lock = xSemaphoreCreateMutex();
+    if (config) {
+        memcpy(&rl->config, config, sizeof(rate_config_t));
+    } else {
+        rl->config.events_per_minute = 30;
+        rl->config.reqs_per_minute = 60;
+    }
+}
+
+static rate_bucket_t* get_bucket(rate_limiter_t *rl, int fd)
+{
+    for (int i = 0; i < RATE_LIMITER_MAX_BUCKETS; i++) {
+        if (rl->buckets[i].active && rl->buckets[i].fd == fd) {
+            return &rl->buckets[i];
+        }
+    }
+    for (int i = 0; i < RATE_LIMITER_MAX_BUCKETS; i++) {
+        if (!rl->buckets[i].active) {
+            rl->buckets[i].fd = fd;
+            rl->buckets[i].active = true;
+            rl->buckets[i].event_count = 0;
+            rl->buckets[i].req_count = 0;
+            rl->buckets[i].window_start = esp_timer_get_time() / 1000000;
+            return &rl->buckets[i];
+        }
+    }
+    return NULL;
+}
+
+bool rate_limiter_check(rate_limiter_t *rl, int fd, rate_type_t type)
+{
+    xSemaphoreTake(rl->lock, portMAX_DELAY);
+
+    rate_bucket_t *bucket = get_bucket(rl, fd);
+    if (!bucket) {
+        xSemaphoreGive(rl->lock);
+        return false;
+    }
+
+    uint32_t now = esp_timer_get_time() / 1000000;
+
+    if (now - bucket->window_start >= 60) {
+        bucket->event_count = 0;
+        bucket->req_count = 0;
+        bucket->window_start = now;
+    }
+
+    bool allowed = true;
+    if (type == RATE_TYPE_EVENT) {
+        if (bucket->event_count >= rl->config.events_per_minute) {
+            ESP_LOGW(TAG, "Rate limited: fd=%d events=%d", fd, bucket->event_count);
+            allowed = false;
+        } else {
+            bucket->event_count++;
+        }
+    } else {
+        if (bucket->req_count >= rl->config.reqs_per_minute) {
+            ESP_LOGW(TAG, "Rate limited: fd=%d reqs=%d", fd, bucket->req_count);
+            allowed = false;
+        } else {
+            bucket->req_count++;
+        }
+    }
+
+    xSemaphoreGive(rl->lock);
+    return allowed;
+}
+
+void rate_limiter_reset(rate_limiter_t *rl, int fd)
+{
+    xSemaphoreTake(rl->lock, portMAX_DELAY);
+    for (int i = 0; i < RATE_LIMITER_MAX_BUCKETS; i++) {
+        if (rl->buckets[i].active && rl->buckets[i].fd == fd) {
+            rl->buckets[i].active = false;
+            break;
+        }
+    }
+    xSemaphoreGive(rl->lock);
+}

--- a/main/rate_limiter.h
+++ b/main/rate_limiter.h
@@ -1,0 +1,39 @@
+#ifndef RATE_LIMITER_H
+#define RATE_LIMITER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+#define RATE_LIMITER_MAX_BUCKETS 16
+
+typedef enum {
+    RATE_TYPE_EVENT,
+    RATE_TYPE_REQ,
+} rate_type_t;
+
+typedef struct {
+    uint16_t events_per_minute;
+    uint16_t reqs_per_minute;
+} rate_config_t;
+
+typedef struct {
+    int      fd;
+    uint16_t event_count;
+    uint16_t req_count;
+    uint32_t window_start;
+    bool     active;
+} rate_bucket_t;
+
+typedef struct rate_limiter {
+    rate_config_t config;
+    rate_bucket_t buckets[RATE_LIMITER_MAX_BUCKETS];
+    SemaphoreHandle_t lock;
+} rate_limiter_t;
+
+void rate_limiter_init(rate_limiter_t *rl, const rate_config_t *config);
+bool rate_limiter_check(rate_limiter_t *rl, int fd, rate_type_t type);
+void rate_limiter_reset(rate_limiter_t *rl, int fd);
+
+#endif

--- a/main/ws_server.h
+++ b/main/ws_server.h
@@ -18,9 +18,6 @@ typedef struct {
     uint32_t connected_at;
     uint32_t last_activity;
     char remote_ip[INET6_ADDRSTRLEN];
-    uint16_t events_this_minute;
-    uint16_t reqs_this_minute;
-    uint32_t rate_window_start;
 } ws_connection_t;
 
 typedef struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting for WebSocket connections (30 events per minute, 60 requests per minute).
  * Added relay information endpoint with CORS header support and content-type negotiation.

* **Refactor**
  * Moved relay information handling to dedicated HTTP handler module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->